### PR TITLE
createUrlByContext has a preg_replace which removed the first slash i…

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -411,7 +411,7 @@ class JiraClient
     {
         $host = $this->getConfiguration()->getJiraHost();
 
-        return $host . $this->getApiUrl() . '/' . preg_replace('/\//', '', $context, 1);
+        return $host . $this->getApiUrl() . '/' . preg_replace('/^\//', '', $context, 1);
     }
 
     /**


### PR DESCRIPTION
…n a string, this breaks when the developer forgets to add an slash at the beginning of the string (https://lulububu.atlassian.net/browse/ROBOTHOMAS-1621)