### PR TITLE
Preserve taskList/taskItem attrs in AtlassianDocumentFormat serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "netresearch/jsonmapper": "^3.0|^4.0",
         "monolog/monolog": "^2.0|^3.0",
         "vlucas/phpdotenv": "^5.0|^6.0",
-        "damienharper/adf-tools": "^1.0"
+        "damienharper/adf-tools": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.0",

--- a/src/ADF/AtlassianDocumentFormat.php
+++ b/src/ADF/AtlassianDocumentFormat.php
@@ -19,6 +19,8 @@ class AtlassianDocumentFormat implements \JsonSerializable
 
     private Document|Node|null $document = null;
 
+    private ?array $rawAdf = null;
+
     public function __construct(Document|Node|string|null $document)
     {
         if (is_string($document)) {
@@ -33,6 +35,10 @@ class AtlassianDocumentFormat implements \JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
+        if (null !== $this->rawAdf) {
+            return $this->rawAdf;
+        }
+
         return $this->document->jsonSerialize();
     }
 
@@ -54,7 +60,10 @@ class AtlassianDocumentFormat implements \JsonSerializable
         /** @var Document $document */
         $document = Document::load($adf);
 
-        return new self($document);
+        $instance = new self($document);
+        $instance->rawAdf = $adf;
+
+        return $instance;
     }
 
     private static function filterUnsupportedNodes(array $data): array

--- a/tests/AtlassianDocumentFormatTest.php
+++ b/tests/AtlassianDocumentFormatTest.php
@@ -157,4 +157,36 @@ class AtlassianDocumentFormatTest extends TestCase
         $serialized = $result->jsonSerialize();
         $this->assertCount(0, $serialized['content']);
     }
+
+    public function testFromArrayPreservesTaskListAndTaskItemAttrs()
+    {
+        $adf = [
+            'version' => 1,
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'taskList',
+                    'attrs' => ['localId' => 'list-1'],
+                    'content' => [
+                        [
+                            'type' => 'taskItem',
+                            'attrs' => ['localId' => 'item-1', 'state' => 'TODO'],
+                            'content' => [
+                                ['type' => 'text', 'text' => 'Do the thing'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $serialized = AtlassianDocumentFormat::fromArray($adf)->jsonSerialize();
+
+        $taskList = $serialized['content'][0];
+        $this->assertSame('list-1', $taskList['attrs']['localId']);
+
+        $taskItem = $taskList['content'][0];
+        $this->assertSame('item-1', $taskItem['attrs']['localId']);
+        $this->assertSame('TODO', $taskItem['attrs']['state']);
+    }
 }


### PR DESCRIPTION
## Problem
`AtlassianDocumentFormat::fromArray()` ran valid ADF through a lossy `DH\Adf` document round-trip (`Document::load()->jsonSerialize()`), which silently dropped `taskList`/`taskItem` `localId` and `state` attrs. The resulting ADF is rejected by the Jira REST API with `INVALID_INPUT`.

Additionally, `damienharper/adf-tools <1.2` does not register `taskList`/`taskItem` in `NODE_MAPPING` at all, so `filterUnsupportedNodes()` dropped task nodes entirely.

## Fix
- `jsonSerialize()` returns the validated **raw ADF array** instead of the lossy DH\Adf round-trip. `Document::load()` still runs as a structural validator.
- Bump `damienharper/adf-tools` to `^1.2` (adds task nodes to `NODE_MAPPING`).
- Regression test asserting `localId`/`state` survive `fromArray -> jsonSerialize`.

## Verification
Verified end-to-end: the produced payload is accepted by the Jira REST API (HTTP 204) where the previous output returned `INVALID_INPUT`. ADF test group green (6/6).

Ref: https://lulububu.atlassian.net/browse/ROBOTHOMAS-3030